### PR TITLE
Better testing

### DIFF
--- a/tests/wpunit/PasswordLockTest.php
+++ b/tests/wpunit/PasswordLockTest.php
@@ -37,10 +37,8 @@ class PasswordLockTest extends WPTestCase
 
         $ciphertext = $passwordLock->hash(self::DUMMY_PASSWORD);
 
-        $info = password_get_info($ciphertext);
-        $this->assertSame(
-            'argon2i',
-            $info['algoName']
+        $this->assertFalse(
+            password_needs_rehash($ciphertext, PASSWORD_ARGON2I, WP_PASSWORD_ARGON_TWO_OPTIONS)
         );
     }
 

--- a/tests/wpunit/WPCheckPasswordTest.php
+++ b/tests/wpunit/WPCheckPasswordTest.php
@@ -91,55 +91,55 @@ class WPCheckPasswordTest extends WPTestCase
     /** @test */
     public function it_checks_correct_bcrypt_hash()
     {
-        $this->assertCorrectPassword('bcryptuser', self::DUMMY_PASSWORD, self::BCRYPT_HASH);
+        $this->assertCorrectPassword('bcrypt_user', self::DUMMY_PASSWORD, self::BCRYPT_HASH);
     }
 
     /** @test */
     public function it_checks_incorrect_bcrypt_hash()
     {
-        $this->assertIncorrectPassword('bcryptuser', 'incorrectPassword', self::BCRYPT_HASH);
+        $this->assertIncorrectPassword('bcrypt_user', 'incorrectPassword', self::BCRYPT_HASH);
     }
 
     /** @test */
     public function it_rehash_bcrypt_hash()
     {
-        $this->assertRehashToArgon2i('bcryptuser', self::DUMMY_PASSWORD, self::BCRYPT_HASH);
+        $this->assertRehashToArgon2i('bcrypt_user', self::DUMMY_PASSWORD, self::BCRYPT_HASH);
     }
 
     /** @test */
     public function it_checks_correct_md5_hash()
     {
-        $this->assertCorrectPassword('md5user', self::DUMMY_PASSWORD, self::MD5_HASH);
+        $this->assertCorrectPassword('md5_user', self::DUMMY_PASSWORD, self::MD5_HASH);
     }
 
     /** @test */
     public function it_checks_incorrect_md5_hash()
     {
-        $this->assertIncorrectPassword('md5user', 'incorrectPassword', self::MD5_HASH);
+        $this->assertIncorrectPassword('md5_user', 'incorrectPassword', self::MD5_HASH);
     }
 
     /** @test */
     public function it_rehash_md5_hash()
     {
-        $this->assertRehashToArgon2i('md5user', self::DUMMY_PASSWORD, self::MD5_HASH);
+        $this->assertRehashToArgon2i('md5_user', self::DUMMY_PASSWORD, self::MD5_HASH);
     }
 
     /** @test */
     public function it_checks_correct_phpass_hash()
     {
-        $this->assertCorrectPassword('phpassuser', self::DUMMY_PASSWORD, self::PHPASS_HASH);
+        $this->assertCorrectPassword('phpass_user', self::DUMMY_PASSWORD, self::PHPASS_HASH);
     }
 
     /** @test */
     public function it_checks_incorrect_phpass_hash()
     {
-        $this->assertIncorrectPassword('phpassuser', 'incorrectPassword', self::PHPASS_HASH);
+        $this->assertIncorrectPassword('phpass_user', 'incorrectPassword', self::PHPASS_HASH);
     }
 
     /** @test */
     public function it_rehash_phpass_hash()
     {
-        $this->assertRehashToArgon2i('phpassuser', self::DUMMY_PASSWORD, self::PHPASS_HASH);
+        $this->assertRehashToArgon2i('phpass_user', self::DUMMY_PASSWORD, self::PHPASS_HASH);
     }
 
     private function assertCorrectPassword(string $login, string $password, string $ciphertext)

--- a/tests/wpunit/WPCheckPasswordTest.php
+++ b/tests/wpunit/WPCheckPasswordTest.php
@@ -12,6 +12,7 @@ class WPCheckPasswordTest extends WPTestCase
 
     // Pepper is defined in TypistTech\WPPasswordArgonTwo\Helper\Wpunit.
     private const ARGON_TWO_HASH = '$argon2i$v=19$m=1024,t=2,p=2$NHE3Vm5aeE8vRExBcVpieA$hf23XqOpqT403Ya0U+Bd+4JhYlMAgNEvFx/CisPkrX4';
+    private const ARGON_TWO_OUTDATED_OPTIONS_HASH = '$argon2i$v=19$m=131072,t=4,p=3$c3drNFJrU21EcjNESUw4ZQ$KboA2MZFKh/O0UEl6T8eMLeEihbWKY6Efeu9TRkbdJM';
     // Fallback pepper is 'my-second-pepper';
     private const ARGON_TWO_FALLBACK_PEPPER_HASH = '$argon2i$v=19$m=1024,t=2,p=2$TUFxYm5XSkJ1b29YLmI5Mg$qn5gHvOEVi1Ixenu7Uax8VWMwu5JW6mM0Ob/kJBwB2A';
     private const BCRYPT_HASH = '$2y$10$EkVBmTI0cbPvPdnTYeVk8eIt6qpHk09C8DB5iZwHbYBu5ot2PyAnq';
@@ -37,6 +38,29 @@ class WPCheckPasswordTest extends WPTestCase
         $user = get_user_by('login', 'argon2user');
         $this->assertSame(
             self::ARGON_TWO_HASH,
+            $user->user_pass
+        );
+    }
+
+    /** @test */
+    public function it_checks_correct_argon2_outdated_options_hash()
+    {
+        $this->assertCorrectPassword('argon2_outdated_options_user', self::DUMMY_PASSWORD, self::ARGON_TWO_OUTDATED_OPTIONS_HASH);
+    }
+
+    /** @test */
+    public function it_checks_incorrect_argon2_outdated_options_hash()
+    {
+        $this->assertIncorrectPassword('argon2_outdated_options_user', 'incorrectPassword', self::ARGON_TWO_OUTDATED_OPTIONS_HASH);
+    }
+
+    /** @test */
+    public function it_rehash_argon2_outdated_options_hash()
+    {
+        $this->assertRehashToArgon2i('argon2_outdated_options_user', self::DUMMY_PASSWORD, self::ARGON_TWO_OUTDATED_OPTIONS_HASH);
+        $user = get_user_by('login', 'argon2_outdated_options_user');
+        $this->assertNotSame(
+            self::ARGON_TWO_OUTDATED_OPTIONS_HASH,
             $user->user_pass
         );
     }
@@ -144,10 +168,8 @@ class WPCheckPasswordTest extends WPTestCase
         wp_check_password($password, $ciphertext, $user->ID);
 
         $user = get_user_by('login', $login);
-        $info = password_get_info($user->user_pass);
-        $this->assertSame(
-            'argon2i',
-            $info['algoName']
+        $this->assertFalse(
+            password_needs_rehash($user->user_pass, PASSWORD_ARGON2I, WP_PASSWORD_ARGON_TWO_OPTIONS)
         );
     }
 

--- a/tests/wpunit/WPHashPasswordTest.php
+++ b/tests/wpunit/WPHashPasswordTest.php
@@ -11,7 +11,7 @@ class WPHashPasswordTest extends WPTestCase
     /** @test */
     public function it_returns_argon2i_hashed_ciphertext()
     {
-        $ciphertext = wp_hash_password('it_returns_argon2i_hashed_ciphertext');
+        $ciphertext = wp_hash_password('testing_it_returns_argon2i_hashed_ciphertext');
 
         $info = password_get_info($ciphertext);
         $this->assertSame(
@@ -23,7 +23,7 @@ class WPHashPasswordTest extends WPTestCase
     /** @test */
     public function its_ciphertext_can_be_checked()
     {
-        $password = 'its_ciphertext_can_be_checked';
+        $password = 'testing_its_ciphertext_can_be_checked';
         $ciphertext = wp_hash_password($password);
         $check = wp_check_password($password, $ciphertext);
 

--- a/tests/wpunit/WPHashPasswordTest.php
+++ b/tests/wpunit/WPHashPasswordTest.php
@@ -13,10 +13,8 @@ class WPHashPasswordTest extends WPTestCase
     {
         $ciphertext = wp_hash_password('testing_it_returns_argon2i_hashed_ciphertext');
 
-        $info = password_get_info($ciphertext);
-        $this->assertSame(
-            'argon2i',
-            $info['algoName']
+        $this->assertFalse(
+            password_needs_rehash($ciphertext, PASSWORD_ARGON2I, WP_PASSWORD_ARGON_TWO_OPTIONS)
         );
     }
 

--- a/tests/wpunit/WPSetPasswordTest.php
+++ b/tests/wpunit/WPSetPasswordTest.php
@@ -13,10 +13,8 @@ class WPSetPasswordTest extends WPTestCase
     {
         $ciphertext = wp_set_password('password', 999);
 
-        $info = password_get_info($ciphertext);
-        $this->assertSame(
-            'argon2i',
-            $info['algoName']
+        $this->assertFalse(
+            password_needs_rehash($ciphertext, PASSWORD_ARGON2I, WP_PASSWORD_ARGON_TWO_OPTIONS)
         );
     }
 
@@ -33,10 +31,8 @@ class WPSetPasswordTest extends WPTestCase
 
         $user = get_user_by('id', $userId);
 
-        $info = password_get_info($user->user_pass);
-        $this->assertSame(
-            'argon2i',
-            $info['algoName']
+        $this->assertFalse(
+            password_needs_rehash($user->user_pass, PASSWORD_ARGON2I, WP_PASSWORD_ARGON_TWO_OPTIONS)
         );
     }
 

--- a/tests/wpunit/WPSetPasswordTest.php
+++ b/tests/wpunit/WPSetPasswordTest.php
@@ -24,9 +24,9 @@ class WPSetPasswordTest extends WPTestCase
     public function it_saves_argon2i_hashed_ciphertext()
     {
         $userId = wp_create_user(
-            'tesing_it_saves_argon2i_hashed_ciphertext',
+            'testing_it_saves_argon2i_hashed_ciphertext',
             'old_password',
-            'tesing_it_saves_argon2i_hashed_ciphertext@exmaple.com'
+            'testing_it_saves_argon2i_hashed_ciphertext@exmaple.com'
         );
 
         wp_set_password('new-password', $userId);
@@ -44,9 +44,9 @@ class WPSetPasswordTest extends WPTestCase
     public function its_ciphertext_can_be_checked()
     {
         $userId = wp_create_user(
-            'tesing_its_ciphertext_can_be_checked',
+            'testing_its_ciphertext_can_be_checked',
             'old_password',
-            'tesing_its_ciphertext_can_be_checked@exmaple.com'
+            'testing_its_ciphertext_can_be_checked@exmaple.com'
         );
 
         $password = 'some-password';


### PR DESCRIPTION
* Add `wp_check_password` rehashes outdated Argon2i options tests
 * More accurate Argon2i hashed assertion